### PR TITLE
Home screen sorting by title

### DIFF
--- a/src/services/api-interface.js
+++ b/src/services/api-interface.js
@@ -35,7 +35,7 @@ export const apiGet = async (id) => {
 // Wrapper for axios get all articles in table
 export const apiGetAll = async () => {
   return await axios.get(apiInterface.route).then((res) => {
-    return res.data.Items.sort((a,b) => {return (a.getPublicationDate > b.getPublicationDate) ?  1 : -1});
+    return res.data.Items.sort((a,b) => {return (a.Title > b.Title) ?  1 : -1});
   });
 }
 


### PR DESCRIPTION
- Updated `api-interface.js` to sort posts by title rather than publicationDate (which doesn't key off of time but off the "Mon", "Tue", "Wed" abbreviation